### PR TITLE
fix for Resonite beta 2024.7.20.94

### DIFF
--- a/CustomInspectors/CustomInspectors.cs
+++ b/CustomInspectors/CustomInspectors.cs
@@ -152,7 +152,7 @@ namespace CustomInspectors
                     var rot = __instance.Slot.GlobalRotation;
                     var scl = __instance.Slot.GlobalScale * config.GetValue(KEY_INSPECTOR_SCALE);
 
-                    __instance.Slot.LoadObject(node, refTranslator: translator);
+                    __instance.Slot.LoadObject(node, null, refTranslator: translator);
                     var old = __instance.Slot.GetComponent<SceneInspector>((insp) => insp != __instance);
 
                     var rt = AccessTools.Field(typeof(SceneInspector), "_rootText");

--- a/CustomInspectors/Properties/AssemblyInfo.cs
+++ b/CustomInspectors/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.3")]
-[assembly: AssemblyFileVersion("2.1.3")]
+[assembly: AssemblyVersion("2.1.4")]
+[assembly: AssemblyFileVersion("2.1.4")]


### PR DESCRIPTION
I would suggest the following as a workaround for exceptions like are.
I tested it and it was successful

```
System.MissingMethodException: void FrooxEngine.Slot.LoadObject(Elements.Core.DataTreeDictionary,FrooxEngine.Slot,System.Predicate`1<System.Type>,FrooxEngine.ReferenceTranslator,System.Func`2<Elements.Core.DataTreeNode, Elements.Core.DataTreeNode>)
   at void FrooxEngine.ComponentBase<FrooxEngine.Component>.RunOnAttach()

   at void Elements.Core.UniLog.Error(string message, bool stackTrace)
   at void FrooxEngine.DebugManager.Error(object obj, bool stackTrace)
   at void FrooxEngine.ComponentBase<FrooxEngine.Component>.RunOnAttach()
   at void FrooxEngine.ContainerWorker<FrooxEngine.Component>.AttachComponentInternal(Component component, bool runOnAttachBehavior, Action<Component> beforeAttach)
   at SceneInspector FrooxEngine.ContainerWorker<FrooxEngine.Component>.AttachComponent<SceneInspector>(bool runOnAttachBehavior, Action<SceneInspector> beforeAttach)
   at void FrooxEngine.DevTool.CreateInspector(Slot target)
   at void FrooxEngine.DevTool.OpenInspector() x 2
   at void FrooxEngine.UIX.ButtonRelay.OnPressed(IButton button, ButtonEventData eventData)
   at void FrooxEngine.UIX.ButtonRelayBase.Pressed(IButton button, ButtonEventData eventData)
   at void FrooxEngine.UIX.Button.RunPressed(ButtonEventData eventData)+(IButtonPressReceiver r) => { }
   at bool FrooxEngine.ContainerWorker<FrooxEngine.Component>.ForeachComponent<IButtonPressReceiver>(Action<IButtonPressReceiver> callback, Func<IButtonPressReceiver, bool> callbackStopper, bool cacheItems, bool excludeDisabled) x 2
   at void MonoMod.Utils.DynamicMethodDefinition.FrooxEngine.UIX.Button.RunPressed_Patch1(Button, ButtonEventData)
   at void FrooxEngine.UIX.Button.OnPressBegin(InteractionData eventData)
   at bool FrooxEngine.UIX.InteractionElement.ProcessEvent(InteractionData eventData)
   at bool FrooxEngine.UIX.Canvas.ProcessTouchEvent(in TouchEventInfo eventInfo, List<Predicate<IUIInteractable>> filters)
   at void FrooxEngine.UIX.Canvas.OnTouch(in TouchEventInfo eventInfo)
   at void FrooxEngine.UIX.Canvas.FrooxEngine.ITouchable.OnTouch(in TouchEventInfo eventInfo)
   at void FrooxEngine.TouchSource.SendTouchEvent(ITouchable touchable, in TouchEventInfo touchInfo)
   at void FrooxEngine.TouchSource.UpdateCurrentTouchable(ITouchable touchable, in float3 point, in float3 direction, in float3 directHitPoint, bool touch)
   at void FrooxEngine.TouchSource.UpdateTouch()
   at void FrooxEngine.InteractionLaser.UpdateLaser(float? maintainDistance, float? overrideSmoothing, InteractionOrigin? overrideOrigin, bool targettingOnly)
   at void FrooxEngine.InteractionHandler.UpdateInteractionAndLaser(bool targettingOnly)
   at void FrooxEngine.InteractionHandler.OnInputEvaluate()
   at void FrooxEngine.InputGroup.Update(float deltaTime)
   at void FrooxEngine.InputBindingManager.Update()
   at bool FrooxEngine.World.RefreshStep()
   at bool FrooxEngine.World.Refresh()
   at void FrooxEngine.WorldManager.UpdateStep()
   at bool FrooxEngine.WorldManager.RunUpdateLoop()
   at void FrooxEngine.Engine.UpdateStep()
   at void FrooxEngine.Engine.RunUpdateLoop()
   at void UnityFrooxEngineRunner.FrooxEngineRunner.UpdateFrooxEngine()
   at void UnityFrooxEngineRunner.FrooxEngineRunner.Update()
```